### PR TITLE
Add brew installation of vsce on Darwin

### DIFF
--- a/VsCode/install.sh
+++ b/VsCode/install.sh
@@ -12,6 +12,11 @@ npm i vscode-languageserver@7.0.0-next.7
 npm i vscode-languageserver-protocol@3.16.0-next.7
 npm i vscode-languageserver-types@3.16.0-next.3
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install vsce
+fi
+
+
 cp -r ../Server/bin/Debug/net7.0 ./server
 npm install
 npm run compile


### PR DESCRIPTION
When running `bash install.sh` on Darwin, I noticed that it would error out on the vcse call. It turns out that vcse is not installed in the install.sh file, nor will a regular npm i @vscode/vsce do the trick (some discussion of this here: https://stackoverflow.com/questions/73025033/vsce-vscode-extension-cli-command-not-found-error).

The suggested fix is to install with homebrew, which indeed fixed the issue for me locally. Since homebrew is only available on macos (and I am on macos darwin), I added a check for this before continuing with the install. This does assume homebrew is installed.